### PR TITLE
Update grant_type_code Test

### DIFF
--- a/authorization-server/test/grant_type_code.js
+++ b/authorization-server/test/grant_type_code.js
@@ -70,13 +70,13 @@ describe('Grant Type Authorization Code', function () {
                 helper.postRefeshToken(tokens.refresh_token, function (error, response, body) {
                   validate.validateAccessToken(response, body);
                 });
-              }
-            );
-            //Try to get the token again but we shouldn't be able to reuse the same code
-            helper.postOAuthCode(code,
-              function (error, response, body) {
-                validate.validateInvalidCodeError(response, body);
-                done();
+                //Try to get the token again but we shouldn't be able to reuse the same code
+                helper.postOAuthCode(code,
+                  function (error, response, body) {
+                    validate.validateInvalidCodeError(response, body);
+                    done();
+                  }
+                );
               }
             );
           }


### PR DESCRIPTION
`grant_type_code` test fails when callbacks are involved (I tested with Postgres and MongoDB). Fixing that.

/cc @selvakn
