### PR TITLE
Fixed tokeninfo endpoint to work again

### DIFF
--- a/authorization-server/package.json
+++ b/authorization-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2orize-authorization-server",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author": "Frank Hassanabad <frankhassanabad@gmail.com>",
   "description": "OAuth2 security recipes and examples based on OAuth2orize",
   "license": "MIT",

--- a/authorization-server/test/token.js
+++ b/authorization-server/test/token.js
@@ -1,0 +1,97 @@
+'use strict';
+
+require('process').env.OAUTHRECIPES_SURPRESS_TRACE = true;
+
+
+const chai             = require('chai');
+const sinonChai        = require('sinon-chai');
+const { accessTokens } = require('../db');
+const utils            = require('../utils');
+const token            = require('../token');
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('token', () => {
+  beforeEach(() => accessTokens.removeAll());
+
+  describe('#info', () => {
+    it('should throw an invalid http 400 on null', () =>
+      token.info({
+        query : { access_token : null },
+      }, {
+        status : (statusCode) => {
+          expect(statusCode).to.eql(400);
+        },
+        json : (message) => {
+          expect(message).eql({ error: 'invalid_token' });
+        },
+      }));
+
+    it('should throw an invalid http 400 on an undefined access token', () =>
+      token.info({
+        query : { },
+      }, {
+        status : (statusCode) => {
+          expect(statusCode).to.eql(400);
+        },
+        json : (message) => {
+          expect(message).eql({ error: 'invalid_token' });
+        },
+      }));
+
+    it('should throw an invalid http 400 on a bunk access token', () =>
+      token.info({
+        query : { access_token : 'abc' },
+      }, {
+        status : (statusCode) => {
+          expect(statusCode).to.eql(400);
+        },
+        json : (message) => {
+          expect(message).eql({ error: 'invalid_token' });
+        },
+      }));
+
+    it('should work with a valid token', () => {
+      const createdToken = utils.createToken();
+      accessTokens.save(createdToken, new Date(0), '1', '1', '*');
+      return token.info({
+        query : { access_token : createdToken },
+      }, {
+        json : (message) => {
+          expect(message.audience).eql('abc123');
+          expect(message).to.have.property('expires_in');
+        },
+      });
+    });
+
+    it('should throw an invalid http 400 on an invalid client', () => {
+      const createdToken = utils.createToken();
+      accessTokens.save(createdToken, new Date(0), '1', '-1', '*');
+      return token.info({
+        query : { access_token : createdToken },
+      }, {
+        status : (statusCode) => {
+          expect(statusCode).to.eql(400);
+        },
+        json : (message) => {
+          expect(message).eql({ error: 'invalid_token' });
+        },
+      });
+    });
+
+    it('should throw an invalid http 400 when no saved token exists', () => {
+      const createdToken = utils.createToken();
+      return token.info({
+        query : { access_token : createdToken },
+      }, {
+        status : (statusCode) => {
+          expect(statusCode).to.eql(400);
+        },
+        json : (message) => {
+          expect(message).eql({ error: 'invalid_token' });
+        },
+      });
+    });
+  });
+});

--- a/authorization-server/test/validate.js
+++ b/authorization-server/test/validate.js
@@ -273,29 +273,22 @@ describe('validate', () => {
   });
 
   describe('#tokenForHttp', () => {
-    it('should return 400 status', () => {
-      try {
-        validate.tokenForHttp();
-      } catch (err) {
-        expect(err.status).to.eql(400);
-      }
-    });
+    it('should return 400 status', () =>
+      validate.tokenForHttp().catch(err => expect(err.status).to.eql(400)));
 
-    it('should reject undefined token', () => {
-      expect(() => validate.tokenForHttp()).to.throw('invalid_token');
-    });
+    it('should reject undefined token', () =>
+      validate.tokenForHttp().catch(err => expect(err.message).to.eql('invalid_token')));
 
-    it('should reject null token`', () => {
-      expect(() => validate.tokenForHttp(null)).to.throw('invalid_token');
-    });
+    it('should reject null token', () =>
+      validate.tokenForHttp(null).catch(err => expect(err.message).to.eql('invalid_token')));
 
-    it('should reject invalid token', () => {
-      expect(() => validate.tokenForHttp('abc')).to.throw('invalid_token');
-    });
+    it('should reject invalid token', () =>
+      validate.tokenForHttp('abc').catch(err => expect(err.message).to.eql('invalid_token')));
 
     it('should work with a valid token', () => {
       const token = utils.createToken();
-      expect(validate.tokenForHttp(token)).eql(token);
+      return validate.tokenForHttp(token)
+      .then(returnedToken => expect(returnedToken).to.eql(token));
     });
   });
 

--- a/authorization-server/token.js
+++ b/authorization-server/token.js
@@ -24,26 +24,19 @@ const validate = require('./validate');
  * @param {Object} res The response
  * @returns {undefined}
  */
-exports.info = [
-  (req, res) => {
-    if (req.query.access_token == null) {
-      res.status(400);
-      res.json({ error: 'invalid_token' });
-      return;
-    }
-    db.accessTokens.find(req.query.access_token)
-    .then(token => validate.tokenForHttp(token))
-    .then(token =>
-      db.clients.find(token.clientID)
-      .then(client => validate.clientExistsForHttp(client))
-      .then(client => ({ client, token })))
-    .then(({ client, token }) => {
-      const expirationLeft = Math.floor((token.expirationDate.getTime() - Date.now()) / 1000);
-      res.json({ audience: client.clientId, expires_in: expirationLeft });
-    })
-    .catch((err) => {
-      res.status(err.status);
-      res.json({ error: err.message });
-    });
-  },
-];
+exports.info = (req, res) =>
+  validate.tokenForHttp(req.query.access_token)
+  .then(() => db.accessTokens.find(req.query.access_token))
+  .then(token => validate.tokenExistsForHttp(token))
+  .then(token =>
+    db.clients.find(token.clientID)
+    .then(client => validate.clientExistsForHttp(client))
+    .then(client => ({ client, token })))
+  .then(({ client, token }) => {
+    const expirationLeft = Math.floor((token.expirationDate.getTime() - Date.now()) / 1000);
+    res.json({ audience : client.clientId, expires_in : expirationLeft });
+  })
+  .catch((err) => {
+    res.status(err.status);
+    res.json({ error: err.message });
+  });

--- a/authorization-server/validate.js
+++ b/authorization-server/validate.js
@@ -198,22 +198,39 @@ validate.generateTokens = (authCode) => {
 };
 
 /**
- * Given a token this will return the token if it is not null and the expiration date has not been
- * exceeded.  Otherwise this will throw a HTTP error.
- * @param   {Object} token - The token to check
- * @throws  {Error}  If the token is invalid or its past its expiration date
- * @returns {Object} The token if it is a valid token
+ * Given a token this will resolve a promise with the token if it is not null and the expiration
+ * date has not been exceeded.  Otherwise this will throw a HTTP error.
+ * @param   {Object}  token - The token to check
+ * @returns {Promise} Resolved with the token if it is a valid token otherwise rejected with error
  */
-validate.tokenForHttp = (token) => {
-  try {
-    utils.verifyToken(token);
-  } catch (err) {
-    const error  = new Error('invalid_token');
+validate.tokenForHttp = token =>
+  new Promise((resolve, reject) => {
+    try {
+      utils.verifyToken(token);
+    } catch (err) {
+      const error  = new Error('invalid_token');
+      error.status = 400;
+      reject(error);
+    }
+    resolve(token);
+  });
+
+/**
+ * Given a token this will return the token if it is not null. Otherwise this will throw a
+ * HTTP error.
+ * @param   {Object} token - The token to check
+ * @throws  {Error}  If the client is null
+ * @returns {Object} The client if it is a valid client
+ */
+validate.tokenExistsForHttp = (token) => {
+  if (token == null) {
+    const error = new Error('invalid_token');
     error.status = 400;
     throw error;
   }
   return token;
 };
+
 
 /**
  * Given a client this will return the client if it is not null. Otherwise this will throw a

--- a/resource-server/package.json
+++ b/resource-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2orize-resource-server",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author": "Frank Hassanabad <frankhassanabad@gmail.com>",
   "description": "OAuth2 security recipes and examples based on OAuth2orize",
   "license": "MIT",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth2orize-web-client",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author": "Frank Hassanabad <frankhassanabad@gmail.com>",  
   "description": "OAuth2 security recipes and examples based on OAuth2orize",
   "license": "MIT",


### PR DESCRIPTION
 * Broke tokeninfo endpoint by accident when moving to promises
 * Added several unit tests to ensure it does not break again
 * Changed the tokeinfo endpoint to be from an array for Express to a non-array to be consistent
 * Added new validate for emptyness