### PR TITLE
Fixes invalid access token which returns from refresh token.

### DIFF
--- a/authorization-server/oauth2.js
+++ b/authorization-server/oauth2.js
@@ -129,10 +129,7 @@ server.exchange(oauth2orize.exchange.clientCredentials((client, scope, done) => 
  */
 server.exchange(oauth2orize.exchange.refreshToken((client, refreshToken, scope, done) => {
   db.refreshTokens.find(refreshToken)
-  .then(foundRefreshToken => {
-    validate.refreshToken(foundRefreshToken, refreshToken, client)
-    return foundRefreshToken;
-  })
+  .then(foundRefreshToken => validate.refreshToken(foundRefreshToken, refreshToken, client))
   .then(foundRefreshToken => validate.generateToken(foundRefreshToken))
   .then(token => done(null, token, null, expiresIn))
   .catch(() => done(null, false));

--- a/authorization-server/oauth2.js
+++ b/authorization-server/oauth2.js
@@ -129,7 +129,10 @@ server.exchange(oauth2orize.exchange.clientCredentials((client, scope, done) => 
  */
 server.exchange(oauth2orize.exchange.refreshToken((client, refreshToken, scope, done) => {
   db.refreshTokens.find(refreshToken)
-  .then(foundRefreshToken => validate.refreshToken(foundRefreshToken, refreshToken, client))
+  .then(foundRefreshToken => {
+    validate.refreshToken(foundRefreshToken, refreshToken, client)
+    return foundRefreshToken;
+  })
   .then(foundRefreshToken => validate.generateToken(foundRefreshToken))
   .then(token => done(null, token, null, expiresIn))
   .catch(() => done(null, false));

--- a/authorization-server/package.json
+++ b/authorization-server/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint *.js config db test",
     "start": "node app.js",
     "test": "mocha test test/db test/config",
-    "test:watch" : "npm run test -- --watch",
+    "test:watch": "npm run test -- --watch",
     "test:integration": "mocha test/integration"
   },
   "engines": {

--- a/authorization-server/test/validate.js
+++ b/authorization-server/test/validate.js
@@ -174,9 +174,9 @@ describe('validate', () => {
         })).to.throw('RefreshToken clientID does not match client id given');
     });
 
-    it('should return refreshToken with everything valid', () => {
+    it('should return token with everything valid', () => {
       const token = utils.createToken();
-      expect(validate.refreshToken({ clientID: '1' }, token, { id : '1' })).to.eql(token);
+      expect(validate.refreshToken({ clientID: '1' }, token, { id : '1' })).to.eql({ clientID: '1' });
     });
   });
 

--- a/authorization-server/validate.js
+++ b/authorization-server/validate.js
@@ -120,7 +120,7 @@ validate.refreshToken = (token, refreshToken, client) => {
   if (client.id !== token.clientID) {
     validate.logAndThrow('RefreshToken clientID does not match client id given');
   }
-  return refreshToken;
+  return token;
 };
 
 /**


### PR DESCRIPTION
Because validate.refreshToken method returns raw refresh token instead of clientID, userID and Scope, When a client request to new access token with using refresh token, it were return invalid access token.